### PR TITLE
Implement solver for Dov's Shkop approach to argumentation semantics

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up Java
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: '14.0.1'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
@@ -27,10 +27,10 @@ jobs:
 
       steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: '14.0.1'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Test with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id 'idea'
 }
 
 repositories {
@@ -27,10 +28,11 @@ repositories {
 }
 
 dependencies {
-    implementation('net.sf.tweety:tweety-full:1.12') { // 1.16
+    implementation('net.sf.tweety:tweety-full:1.17') {
         exclude group: 'org.ojalgo', module: 'ojalgo'
         exclude group: 'jspf', module: 'core'
     }
+    implementation("com.google.guava:guava:29.0-jre")
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.6.1'
 }
 

--- a/src/main/java/diarg/Semantics.java
+++ b/src/main/java/diarg/Semantics.java
@@ -27,7 +27,7 @@ public class Semantics {
     public Collection<Extension> getModels(DungTheory framework) {
         switch (this.semanticsType) {
             case CF2:
-                SimpleCF2Reasoner cf2Reasoner = new SimpleCF2Reasoner();
+                SccCF2Reasoner cf2Reasoner = new SccCF2Reasoner();
                 return cf2Reasoner.getModels(framework);
             case COMPLETE:
                 SimpleCompleteReasoner completeReasoner = new SimpleCompleteReasoner();

--- a/src/main/java/diarg/Serializer.java
+++ b/src/main/java/diarg/Serializer.java
@@ -12,7 +12,6 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.codehaus.jettison.json.JSONArray;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 

--- a/src/main/java/diarg/SimpleShkopReasoner.java
+++ b/src/main/java/diarg/SimpleShkopReasoner.java
@@ -1,0 +1,110 @@
+package diarg;
+
+import net.sf.tweety.arg.dung.reasoner.AbstractExtensionReasoner;
+import net.sf.tweety.arg.dung.reasoner.SimpleGroundedReasoner;
+import net.sf.tweety.arg.dung.semantics.Extension;
+import net.sf.tweety.arg.dung.syntax.Argument;
+import net.sf.tweety.arg.dung.syntax.Attack;
+import net.sf.tweety.arg.dung.syntax.DungTheory;
+
+import com.google.common.collect.Collections2;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Determines the Shkop extensions, given any argumentation framework AF = (AR, AT), as follows:
+ * 1. Generate all permutation sequences of AR.
+ * 2. For each permutation, construct the permution's Shkop framework.
+ *    Start with an empty framework ("Shkop framework") and add the permutation's arguments one-by-one,
+ *    following the order of the permutation sequence. For each argument:
+ *    2.1. Add the argument to the Shkop framework and add all attack relations in AT that exist between the argument
+ *         and arguments in the Shkop framework.
+ *    2.2. If the argument "closes a loop" in the Shkop framework, i.e., if the argument is self-attacking or in an SCC
+ *         such that |SCC| > 1, remove the argument from the Shkop framework.
+ * 3. Remove duplicated Shkop frameworks, then determine their grounded extensions.
+ *    Note that Shkop-frameworks are always acyclic.
+ * 4. Return the grounded extensions.
+ *
+ * @author Timotheus Kampik
+ * @author Dov Gabbay
+ */
+
+public class SimpleShkopReasoner extends AbstractExtensionReasoner {
+
+    private SimpleGroundedReasoner groundedReasoner = new SimpleGroundedReasoner();
+
+    /* (non-Javadoc)
+     * @see net.sf.tweety.arg.dung.reasoner.AbstractExtensionReasoner#getModels(net.sf.tweety.arg.dung.syntax.DungTheory)
+     */
+    @Override
+    public Collection<Extension> getModels(DungTheory bbase) {
+        Collection<DungTheory> permutationFrameworks = new ArrayList<>();
+        Collection<Extension> extensions = new LinkedList<>();
+        ArrayList args = new ArrayList(bbase.getNodes());
+        Collection<List<Argument>> permutations = Collections2.permutations(args);
+        for(List<Argument> permutation: permutations) {
+            DungTheory framework = new DungTheory();
+            for(Argument argument: permutation) {
+                DungTheory counterfactualFramework = new DungTheory();
+                counterfactualFramework.add(framework);
+                counterfactualFramework = shkopExpandFramework(bbase, counterfactualFramework, argument);
+                Collection<Collection<Argument>> sccs = counterfactualFramework.getStronglyConnectedComponents();
+                boolean addsCycle = false;
+                for(Collection<Argument> scc: sccs) {
+                    if(scc.size() > 1) {
+                        addsCycle = true;
+                        break;
+                    }
+                }
+                if(!addsCycle) {
+                    framework = shkopExpandFramework(bbase, framework, argument);
+                }
+            }
+            if(!permutationFrameworks.contains(framework)){
+                System.out.println(framework);
+                permutationFrameworks.add(framework);
+            }
+        }
+
+        for(DungTheory permutationNetwork: permutationFrameworks) {
+                Extension extension = groundedReasoner.getModels(permutationNetwork).iterator().next();
+                if(!extensions.contains(extension)) {
+                    extensions.add(extension);
+                }
+        }
+        return extensions;
+    }
+
+    /* (non-Javadoc)
+     * @see net.sf.tweety.arg.dung.reasoner.AbstractExtensionReasoner#getModel(net.sf.tweety.arg.dung.syntax.DungTheory)
+     */
+    @Override
+    public Extension getModel(DungTheory bbase) {
+        Collection<Extension> extensions = this.getModels(bbase);
+        return extensions.iterator().next();
+    }
+
+    /**
+     * Shkop-expands a permutation by adding the "next" argument and its attack relations
+     * to all existing arguments (according to the base framework) to a gradually expanded permutation
+     * @param bbase Original framework that is to be resolved
+     * @param currentFramework Current permutation-based Shkop-framework
+     * @param argument Argument that should be added to the current framework
+     * @return Shkop-expanded argumentation framework
+     */
+    private static DungTheory shkopExpandFramework(
+            DungTheory bbase, DungTheory currentFramework, Argument argument) {
+        currentFramework.add(argument);
+        for(Attack attack: bbase.getAttacks()) {
+            if(     !currentFramework.contains(attack) &&
+                    currentFramework.contains(attack.getNodeA()) &&
+                    currentFramework.contains(attack.getNodeB())) {
+                currentFramework.add(attack);
+            }
+        }
+        return currentFramework;
+    }
+}

--- a/src/main/java/diarg/SimpleShkopReasoner.java
+++ b/src/main/java/diarg/SimpleShkopReasoner.java
@@ -23,7 +23,7 @@ import java.util.List;
  *    2.1. Add the argument to the Shkop framework and add all attack relations in AT that exist between the argument
  *         and arguments in the Shkop framework.
  *    2.2. If the argument "closes a loop" in the Shkop framework, i.e., if the argument is self-attacking or in an SCC
- *         such that |SCC| > 1, remove the argument from the Shkop framework.
+ *         such that |SCC| greater than 1, remove the argument from the Shkop framework.
  * 3. Remove duplicated Shkop frameworks, then determine their grounded extensions.
  *    Note that Shkop-frameworks are always acyclic.
  * 4. Return the grounded extensions.
@@ -54,7 +54,7 @@ public class SimpleShkopReasoner extends AbstractExtensionReasoner {
                 Collection<Collection<Argument>> sccs = counterfactualFramework.getStronglyConnectedComponents();
                 boolean addsCycle = false;
                 for(Collection<Argument> scc: sccs) {
-                    if(scc.size() > 1) {
+                    if(scc.size() > 1 || bbase.contains(new Attack(argument, argument))) {
                         addsCycle = true;
                         break;
                     }
@@ -64,7 +64,6 @@ public class SimpleShkopReasoner extends AbstractExtensionReasoner {
                 }
             }
             if(!permutationFrameworks.contains(framework)){
-                System.out.println(framework);
                 permutationFrameworks.add(framework);
             }
         }

--- a/src/test/java/diarg/SimpleShkopReasonerTest.java
+++ b/src/test/java/diarg/SimpleShkopReasonerTest.java
@@ -1,0 +1,53 @@
+package diarg;
+
+import net.sf.tweety.arg.dung.semantics.Extension;
+import net.sf.tweety.arg.dung.syntax.Argument;
+import net.sf.tweety.arg.dung.syntax.DungTheory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SimpleShkopReasonerTest {
+    SimpleShkopReasoner shkopReasoner = new SimpleShkopReasoner();
+
+    @Test
+    void testShkopReasoner() {
+        Argument a = new Argument("a");
+        Argument b = new Argument("b");
+        Argument c = new Argument("c");
+        Argument d = new Argument("d");
+        Argument e = new Argument("e");
+        Argument f = new Argument("f");
+
+        TestFrameworks testFrameworks = new TestFrameworks();
+
+        DungTheory framework1 = testFrameworks.framework1;
+        Collection<Extension> extensions1 = shkopReasoner.getModels(framework1);
+        assertEquals(3, extensions1.size());
+        Extension extension1a = new Extension();
+        extension1a.add(a);
+        extension1a.add(c);
+        assertTrue(extensions1.contains(extension1a));
+        Extension extension1b = new Extension();
+        extension1b.add(a);
+        extension1b.add(d);
+        assertTrue(extensions1.contains(extension1b));
+        Extension extension1c = new Extension();
+        extension1c.add(a);
+        extension1c.add(e);
+        assertTrue(extensions1.contains(extension1c));
+
+        DungTheory framework2 = testFrameworks.framework2;
+        Collection<Extension> extensions2 = shkopReasoner.getModels(framework2);
+        assertEquals(2, extensions2.size());
+        Extension extension2b = new Extension();
+        extension2b.add(b);
+        assertTrue(extensions2.contains(extension2b));
+        Extension extension2c = new Extension();
+        extension2c.add(c);
+        assertTrue(extensions2.contains(extension2c));
+    }
+}

--- a/src/test/java/diarg/SimpleShkopReasonerTest.java
+++ b/src/test/java/diarg/SimpleShkopReasonerTest.java
@@ -49,5 +49,119 @@ public class SimpleShkopReasonerTest {
         Extension extension2c = new Extension();
         extension2c.add(c);
         assertTrue(extensions2.contains(extension2c));
+
+        // Test examples form Argumentation Handbook
+        HandbookTestFrameworks hbtFrameworks = new HandbookTestFrameworks();
+        DungTheory hbtFramework1 = hbtFrameworks.framework1;
+        Collection<Extension> extensionsHBT1 = shkopReasoner.getModels(hbtFramework1);
+        assertEquals(1, extensionsHBT1.size());
+        Extension extensionHBT1a = new Extension();
+        extensionHBT1a.add(a);
+        extensionHBT1a.add(c);
+        assertTrue(extensionsHBT1.contains(extensionHBT1a));
+
+        DungTheory hbtFramework2 = hbtFrameworks.framework2;
+        Collection<Extension> extensionsHBT2 = shkopReasoner.getModels(hbtFramework2);
+        assertEquals(2, extensionsHBT2.size());
+        Extension extensionHBT2a = new Extension();
+        extensionHBT2a.add(a);
+        assertTrue(extensionsHBT2.contains(extensionHBT2a));
+        Extension extensionHBT2b = new Extension();
+        extensionHBT2b.add(b);
+        assertTrue(extensionsHBT2.contains(extensionHBT2b));
+
+        DungTheory hbtFramework3 = hbtFrameworks.framework3;
+        Collection<Extension> extensionsHBT3 = shkopReasoner.getModels(hbtFramework3);
+        assertEquals(2, extensionsHBT3.size());
+        Extension extensionHBT3a = new Extension();
+        extensionHBT3a.add(a);
+        extensionHBT3a.add(c);
+        assertTrue(extensionsHBT3.contains(extensionHBT3a));
+        Extension extensionHBT3b = new Extension();
+        extensionHBT3b.add(a);
+        extensionHBT3b.add(d);
+        assertTrue(extensionsHBT3.contains(extensionHBT3b));
+
+        DungTheory hbtFramework4 = hbtFrameworks.framework4;
+        Collection<Extension> extensionsHBT4 = shkopReasoner.getModels(hbtFramework4);
+        assertEquals(2, extensionsHBT3.size());
+        Extension extensionHBT4a = new Extension();
+        extensionHBT4a.add(a);
+        extensionHBT4a.add(d);
+        assertTrue(extensionsHBT4.contains(extensionHBT4a));
+        Extension extensionHBT4b = new Extension();
+        extensionHBT4b.add(b);
+        extensionHBT4b.add(d);
+        assertTrue(extensionsHBT4.contains(extensionHBT4b));
+
+        DungTheory hbtFramework5 = hbtFrameworks.framework5;
+        Collection<Extension> extensionsHBT5 = shkopReasoner.getModels(hbtFramework5);
+        assertEquals(3, extensionsHBT5.size());
+        Extension extensionHBT5a = new Extension();
+        extensionHBT5a.add(a);
+        assertTrue(extensionsHBT5.contains(extensionHBT5a));
+        Extension extensionHBT5b = new Extension();
+        extensionHBT5b.add(b);
+        assertTrue(extensionsHBT5.contains(extensionHBT5b));
+        Extension extensionHBT5c = new Extension();
+        extensionHBT5c.add(c);
+        assertTrue(extensionsHBT5.contains(extensionHBT5c));
+
+        DungTheory hbtFramework6 = hbtFrameworks.framework6;
+        Collection<Extension> extensionsHBT6 = shkopReasoner.getModels(hbtFramework6);
+        assertEquals(5, extensionsHBT6.size());
+        Extension extensionHBT6a = new Extension();
+        extensionHBT6a.add(a);
+        extensionHBT6a.add(c);
+        assertTrue(extensionsHBT6.contains(extensionHBT6a));
+        Extension extensionHBT6b = new Extension();
+        extensionHBT6b.add(a);
+        extensionHBT6b.add(d);
+        assertTrue(extensionsHBT6.contains(extensionHBT6b));
+        Extension extensionHBT6c = new Extension();
+        extensionHBT6c.add(a);
+        extensionHBT6c.add(e);
+        assertTrue(extensionsHBT6.contains(extensionHBT6c));
+        Extension extensionHBT6d = new Extension();
+        extensionHBT6d.add(b);
+        extensionHBT6d.add(d);
+        assertTrue(extensionsHBT6.contains(extensionHBT6d));
+        Extension extensionHBT6e = new Extension();
+        extensionHBT6e.add(b);
+        extensionHBT6e.add(e);
+        assertTrue(extensionsHBT6.contains(extensionHBT6e));
+
+        DungTheory hbtFramework7 = hbtFrameworks.framework7;
+        Collection<Extension> extensionsHBT7 = shkopReasoner.getModels(hbtFramework7);
+        assertEquals(2, extensionsHBT7.size());
+        Extension extensionHBT7a = new Extension();
+        extensionHBT7a.add(a);
+        assertTrue(extensionsHBT7.contains(extensionHBT7a));
+        Extension extensionHBT7b = new Extension();
+        extensionHBT7b.add(b);
+        assertTrue(extensionsHBT7.contains(extensionHBT7b));
+
+        DungTheory hbtFramework8 = hbtFrameworks.framework8;
+        Collection<Extension> extensionsHBT8 = shkopReasoner.getModels(hbtFramework8);
+        assertEquals(1, extensionsHBT8.size());
+        Extension extensionHBT8a = new Extension();
+        extensionHBT8a.add(b);
+        assertTrue(extensionsHBT8.contains(extensionHBT8a));
+
+        DungTheory hbtFramework9 = hbtFrameworks.framework9;
+        Collection<Extension> extensionsHBT9 = shkopReasoner.getModels(hbtFramework9);
+        assertEquals(1, extensionsHBT9.size());
+        Extension extensionHBT9a = new Extension();
+        extensionHBT9a.add(a);
+        assertTrue(extensionsHBT9.contains(extensionHBT9a));
+
+        DungTheory hbtFramework10 = hbtFrameworks.framework10;
+        Collection<Extension> extensionsHBT10 = shkopReasoner.getModels(hbtFramework10);
+        assertEquals(1, extensionsHBT10.size());
+        Extension extensionHBT10a = new Extension();
+        extensionHBT10a.add(a);
+        extensionHBT10a.add(e);
+        extensionHBT10a.add(f);
+        assertTrue(extensionsHBT10.contains(extensionHBT10a));
     }
 }


### PR DESCRIPTION
Determines the Shkop extensions, given any argumentation framework AF = (AR, AT), as follows:
1. Generate all permutation sequences of AR.
2. For each permutation, construct the permution's Shkop framework.
    Start with an empty framework ("Shkop framework") and add the permutation's arguments one-by-one,
    following the order of the permutation sequence. For each argument:
    2.1. Add the argument to the Shkop framework and add all attack relations in AT that exist between the argument
         and arguments in the Shkop framework.
    2.2. If the argument "closes a loop" in the Shkop framework, i.e., if the argument is self-attacking or in an SCC
         such that |SCC| > 1, remove the argument from the Shkop framework.
3. Remove duplicated Shkop frameworks, then determine their grounded extensions.
   Note that Shkop-frameworks are always acyclic.
4. Return the grounded extensions.